### PR TITLE
Enable to set JSON endpoints to "none" #61 #70 #72 #74

### DIFF
--- a/JitsiMeetOutlook/JitsiApiService.cs
+++ b/JitsiMeetOutlook/JitsiApiService.cs
@@ -37,6 +37,9 @@ namespace JitsiMeetOutlook
 
         public async Task<string> getPIN(string roomName)
         {
+            if (Properties.Settings.Default.conferenceMapperEndpoint.ToLower() == "none") {
+                return "";
+            }
             string conferenceMapperRequestUrl = $"{Properties.Settings.Default.conferenceMapperEndpoint}?conference={roomName}@conference.{JitsiUrl.getDomain()}";
 
             try
@@ -58,6 +61,9 @@ namespace JitsiMeetOutlook
 
         public async Task<PhoneNumberListResponse> getPhoneNumbers(string roomName)
         {
+            if (Properties.Settings.Default.phoneNumberListEndpoint.ToLower() == "none") {
+                return new PhoneNumberListResponse { Numbers = new Dictionary<string, List<string>>() };
+            }
             string phoneNumberListRequestUrl = $"{Properties.Settings.Default.phoneNumberListEndpoint}?conference={roomName}@conference.{JitsiUrl.getDomain()}";
             try
             {

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ As of v0.4.0, the add-in can be installed via command line with custom setting p
 - `NOAUDIO`: Mute audio by default in new Jitsi Meet appointments. (True/False)
 - `NOVIDEO`: Disable video by default in new Jitsi Meet appointments. (True/False)
 - `LANG`: Specify the display language. Currently, English, French, German, and Russian are available. (en/fr/de/ru)
-- `CONFERENCEMAPPER_ENDPOINT`: Endpoint to get the Conference PIN from
-- `PHONENUMBERLIST_ENDPOINT`: Endpoint to get the Phone Number from to call in
+- `CONFERENCEMAPPER_ENDPOINT`: Endpoint to get the Conference PIN from. Set to "none" if dial-in is not supported.
+- `PHONENUMBERLIST_ENDPOINT`: Endpoint to get the Phone Number from to call in. Set to "none" if dial-in is not supported.
 - `CONFERENCESCHEDULER_ENDPOINT`: Endpoint to send the conference information to in advance, in order to make the call available for call in before the first person joins
 - `CONFERENCESCHEDULER_ENDPOINT_SECRET`: Secret for the `CONFERENCESCHEDULER_ENDPOINT`, used for JWT generation.
 


### PR DESCRIPTION
When a local installation does not provide Dial-in access, there is no need for listing phone numbers and conference PINs. Both lists usually are gathered by

- CONFERENCEMAPPER_ENDPOINT
- PHONENUMBERLIST_ENDPOINT

Enable a value of "none" in the installer to skip trying to retrieve the numbers and PINs.